### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/config-apply-action/security/code-scanning/1](https://github.com/qbee-io/config-apply-action/security/code-scanning/1)

To fix the problem, we should explicitly set the minimal required permissions for the job or the workflow by adding a `permissions` block. In this case, since the job does not appear to perform any repository write operations, the minimum permission needed is likely `contents: read`. This can be set at the root of the workflow (to apply to all jobs), or within the specific job definition. The best way to fix this is to add `permissions: contents: read` at the root level just after the workflow name (after line 1), ensuring least privilege is enforced for all jobs in the workflow. No additional imports or definitions are required for this YAML fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
